### PR TITLE
Prepare addon for Odoo 19 compatibility

### DIFF
--- a/voodoo_devices/MIGRATION.md
+++ b/voodoo_devices/MIGRATION.md
@@ -1,0 +1,21 @@
+# Odoo 19 Migration Guide for Voodoo Devices
+
+## Prerequisites
+- **Odoo**: 19.0 (community or enterprise).
+- **Python**: 3.12 (per Odoo 19 requirements).
+- **queue_job**: OCA `queue_job` 19.0 (must be installed/enabled because this addon uses `with_delay`).
+- **Optional stock modules**: install `stock_picking_batch` and/or `stock_picking_wave` only if you enable the related views/models in this addon.
+
+## Manual Steps
+1. **Update dependencies**: ensure `queue_job` is installed and compatible with Odoo 19.
+2. **Update addons list**: restart Odoo and update the app list.
+3. **Install/upgrade the addon**: upgrade `voodoo_devices` from Apps.
+4. **Re-enter credentials**: open *Settings → Voodoo Devices* and confirm the endpoint, username, and password.
+5. **Validate user preferences**: verify each user has a `Voodoo Device Color`, `Voodoo Device Beep`, and `Voodoo Seconds` configured.
+6. **Optional batch/wave support**: if using picking batches or waves, uncomment the related `depends` and model imports, then upgrade the addon.
+
+## Rollback Plan
+1. **Uninstall the addon**: remove `voodoo_devices` from Apps.
+2. **Disable queue jobs**: stop workers or disable `queue_job` to prevent background tasks.
+3. **Restore database backup**: revert to the pre-migration snapshot if needed.
+4. **Restart Odoo**: clear caches and confirm baseline stock operations work.

--- a/voodoo_devices/__manifest__.py
+++ b/voodoo_devices/__manifest__.py
@@ -6,10 +6,10 @@
     'author': 'Voodoo Robotics',
     'website': 'https://voodoorobotics.com/',
 #   Choose which line to uncomment below based on your use of batch or wave picking
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_batch', 'stock_picking_wave'],
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_batch'],
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_wave'],
-    'depends': ['stock','stock_sms','queue_job', 'web'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_batch', 'stock_picking_wave'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_batch'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_wave'],
+    'depends': ['stock','queue_job', 'web'],
     
     
     'data': [

--- a/voodoo_devices/controllers/main.py
+++ b/voodoo_devices/controllers/main.py
@@ -6,24 +6,27 @@ class ExternalRpcController(http.Controller):
 
     @http.route('/external_rpc/receive', type='json', auth='user')
     def receive_call_back(self, **kwargs):
-        
-        data = json.loads(request.httprequest.data)
+        data = request.jsonrequest or {}
         qty = data.get('qty')
         ack = data.get('acknack')
         nonce = data.get('nonce')
-        
-        move_id = json.loads(nonce).get('moveid')
-           
-        if ack and qty>0:
+
+        move_id = None
+        if nonce:
+            move_id = json.loads(nonce).get('moveid')
+
+        if ack and qty and qty > 0 and move_id:
             # Retrieve the stock.move record
             move = request.env['stock.move'].browse(move_id)
-            
-            # Update the done quantity
-            move.write({'quantity_done': qty})
 
-            return {"status": "success", "message": "Quantity updated successfully"}
-        else:
-            return {"status": "success", "message": "Quantity not updated"}
+            if move.exists():
+                # Update the done quantity
+                move.write({'quantity_done': qty})
+                return {"status": "success", "message": "Quantity updated successfully"}
+
+            return {"status": "error", "message": "Move not found"}
+
+        return {"status": "success", "message": "Quantity not updated"}
 
 
 

--- a/voodoo_devices/views/stock_location_view_extension.xml
+++ b/voodoo_devices/views/stock_location_view_extension.xml
@@ -6,8 +6,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='replenish_location']" position="after">
                 <field name="voodoo_device_id"/>
-                <field name="voodoo_device_orientation" readonly="not voodoo_device_id"/>
-            </xpath>            
+                <field name="voodoo_device_orientation" attrs="{'readonly': [('voodoo_device_id', '=', False)]}"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
### Motivation
- Remove a deprecated dependency and update small compatibility issues so the addon installs and runs under Odoo 19.
- Make controller JSON parsing robust with modern Odoo request APIs to avoid malformed/encoding issues and to guard against missing data.
- Ensure view attribute expressions follow newer view engine expectations and document migration steps and runtime requirements (notably `queue_job`).

### Description
- Updated dependency list in `__manifest__.py` to remove the deprecated `stock_sms` entry and document optional batch/wave dependencies, changing `depends` to `['stock','queue_job','web']` (manifest lines around the dependency block). 
- Rewrote the JSON endpoint parsing in `voodoo_devices/controllers/main.py` to use `request.jsonrequest` and added validation for `nonce`, `moveid`, and `move.exists()` before writing `quantity_done` to avoid exceptions on bad input (controller body change). 
- Replaced brittle inline `readonly` expression with an `attrs` modifier in `voodoo_devices/views/stock_location_view_extension.xml` to make `voodoo_device_orientation` readonly when `voodoo_device_id` is unset (view xpath change). 
- Added `MIGRATION.md` at the module root documenting prerequisites (Odoo 19, Python 3.12, `queue_job`), manual upgrade steps, and a rollback plan. 

### Testing
- No automated tests were available for this repository, so no automated tests were executed (changes were limited to manifest, controller parsing, view attrs, and documentation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a099f9b4832b9346569cd783a547)