### PR TITLE
Update for Odoo 18 compatibility (manifest, settings, view attrs, migration notes)

### DIFF
--- a/voodoo_devices/MIGRATION.md
+++ b/voodoo_devices/MIGRATION.md
@@ -1,0 +1,20 @@
+# Odoo 18 Migration Notes for `voodoo_devices`
+
+## Prerequisites
+- **Odoo**: 18.0 (Community or Enterprise).
+- **Python**: 3.10+ (match the Odoo 18 runtime).
+- **queue_job**: 18.0-compatible release from OCA (install and add to `server_wide_modules` if you use job workers).
+- **Workers**: enable workers in `odoo.conf` when using `queue_job`.
+
+## Manual Steps
+1. Update your addons path to include this module.
+2. Ensure the OCA `queue_job` addon is installed and listed in `server_wide_modules` (e.g., `web,queue_job`).
+3. Review and update the dependency list if you previously used `stock_sms` (this module no longer requires it).
+4. Configure **Settings → Voodoo Devices** with the endpoint URL, username, and password.
+5. If using batch or wave picking, uncomment the relevant model and view extensions in the addon.
+
+## Rollback Plan
+1. Uninstall the `voodoo_devices` addon from Apps.
+2. Restore the previous addon version from backup (including prior manifest/configuration).
+3. Restart Odoo and verify that `queue_job` workers return to their previous configuration.
+4. Reinstall the previous addon version if needed and reapply your previous settings.

--- a/voodoo_devices/__manifest__.py
+++ b/voodoo_devices/__manifest__.py
@@ -1,15 +1,15 @@
 {
     'name': 'Voodoo Devices',
-    'version': '1.0',
+    'version': '18.0.1.0.0',
     'category': 'Warehouse',
     'summary': 'Enhance warehouse efficiency with this Odoo addon from Voodoo Robotics, seamlessly integrating IoT pick-to-light systems for optimized picking, putting, kitting, and more, streamlining operations with real-time guidance and automation.',
     'author': 'Voodoo Robotics',
     'website': 'https://voodoorobotics.com/',
 #   Choose which line to uncomment below based on your use of batch or wave picking
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_batch', 'stock_picking_wave'],
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_batch'],
-#    'depends': ['stock','stock_sms','queue_job', 'web', 'stock_picking_wave'],
-    'depends': ['stock','stock_sms','queue_job', 'web'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_batch', 'stock_picking_wave'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_batch'],
+#    'depends': ['stock','queue_job', 'web', 'stock_picking_wave'],
+    'depends': ['stock','queue_job', 'web'],
     
     
     'data': [

--- a/voodoo_devices/models/res_config_settings.py
+++ b/voodoo_devices/models/res_config_settings.py
@@ -1,27 +1,22 @@
-from odoo import api, models, fields
+from odoo import models, fields
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
     # _name = 'voodoo.settings'
 
-    endpoint_url = fields.Char(string='Voodoo Endpoint URL',default='https://www.voodoodevices.com/api/',help="Should end in /api/")
-    username = fields.Char(string='Username',default='myusername')
-    password = fields.Char(string='Password',default='mypassword')
-
-    @api.model
-    def get_values(self):
-        res = super(ResConfigSettings, self).get_values()
-        ICPSudo = self.env['ir.config_parameter'].sudo()
-        res.update(
-            endpoint_url=ICPSudo.get_param('voodoo.endpoint_url'),
-            username=ICPSudo.get_param('voodoo.username'),
-            password=ICPSudo.get_param('voodoo.password'),
-        )
-        return res
-
-    def set_values(self):
-        ICPSudo = self.env['ir.config_parameter'].sudo()
-        ICPSudo.set_param('voodoo.endpoint_url', self.endpoint_url or '')
-        ICPSudo.set_param('voodoo.username', self.username or '')
-        ICPSudo.set_param('voodoo.password', self.password or '')
-        super(ResConfigSettings, self).set_values()
+    endpoint_url = fields.Char(
+        string='Voodoo Endpoint URL',
+        default='https://www.voodoodevices.com/api/',
+        help="Should end in /api/",
+        config_parameter='voodoo.endpoint_url',
+    )
+    username = fields.Char(
+        string='Username',
+        default='myusername',
+        config_parameter='voodoo.username',
+    )
+    password = fields.Char(
+        string='Password',
+        default='mypassword',
+        config_parameter='voodoo.password',
+    )

--- a/voodoo_devices/views/stock_location_view_extension.xml
+++ b/voodoo_devices/views/stock_location_view_extension.xml
@@ -6,8 +6,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='replenish_location']" position="after">
                 <field name="voodoo_device_id"/>
-                <field name="voodoo_device_orientation" readonly="not voodoo_device_id"/>
-            </xpath>            
+                <field name="voodoo_device_orientation" attrs="{'readonly': [('voodoo_device_id', '=', False)]}"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
### Motivation
- Bring the module into Odoo 18 compatibility by updating metadata, view modifiers, and configuration persistence patterns.
- Remove or adapt dependencies and APIs that are likely to be missing or problematic in typical Odoo 18 installs.
- Provide migration notes so upgrades to Odoo 18 are repeatable and reversible.

### Description
- Bumped module `version` to an Odoo 18 style string (`18.0.1.0.0`) and removed `stock_sms` from the default `depends` list in `__manifest__.py` so installation does not fail where that module is absent. 
- Replaced manual `get_values`/`set_values` handling with `config_parameter`-backed fields in `models/res_config_settings.py` so settings persist via Odoo's recommended API. 
- Rewrote the dynamic `readonly` logic in `views/stock_location_view_extension.xml` to use `attrs` (`{'readonly': [('voodoo_device_id','=',False)]}`) which is the supported modifier style in newer view engines. 
- Added `MIGRATION.md` with prerequisites, manual upgrade steps, and a rollback plan describing queue_job and worker expectations.

### Testing
- No automated tests were found in the repository, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a39a704c832bb217c90ee7ee1c8f)