### PR TITLE
Update manifest version, bind settings to config parameters, and document stock_sms requirement

### DIFF
--- a/voodoo_devices/README.md
+++ b/voodoo_devices/README.md
@@ -7,6 +7,8 @@ Please note that if you're using BATCH or WAVE picking, there are three things y
 2) in the __manifest__.py file, you must uncomment any view_extension.xml line needed for your GUI.
 3) in the models/__init__.py file, you need to uncomment the lines to support your picking type.
 
+Since the manifest no longer lists `stock_sms` as a dependency, ensure that module is installed in your Odoo environment if you rely on SMS notifications.
+
 After activating this addon, you need to enter your Voodoo Devices credentials in the Settings panel and, if you're using feedback, you need to enter your Odoo credentials on you BigBlock server under the Setting tab.
 
 Since this addon depends on the queue_job addon, you may need to add the following to your odoo.conf file:

--- a/voodoo_devices/__manifest__.py
+++ b/voodoo_devices/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Voodoo Devices',
-    'version': '1.0',
+    'version': '19.0.1.0.0',
     'category': 'Warehouse',
     'summary': 'Enhance warehouse efficiency with this Odoo addon from Voodoo Robotics, seamlessly integrating IoT pick-to-light systems for optimized picking, putting, kitting, and more, streamlining operations with real-time guidance and automation.',
     'author': 'Voodoo Robotics',

--- a/voodoo_devices/models/res_config_settings.py
+++ b/voodoo_devices/models/res_config_settings.py
@@ -4,9 +4,22 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
     # _name = 'voodoo.settings'
 
-    endpoint_url = fields.Char(string='Voodoo Endpoint URL',default='https://www.voodoodevices.com/api/',help="Should end in /api/")
-    username = fields.Char(string='Username',default='myusername')
-    password = fields.Char(string='Password',default='mypassword')
+    endpoint_url = fields.Char(
+        string='Voodoo Endpoint URL',
+        default='https://www.voodoodevices.com/api/',
+        help="Should end in /api/",
+        config_parameter='voodoo.endpoint_url',
+    )
+    username = fields.Char(
+        string='Username',
+        default='myusername',
+        config_parameter='voodoo.username',
+    )
+    password = fields.Char(
+        string='Password',
+        default='mypassword',
+        config_parameter='voodoo.password',
+    )
 
     @api.model
     def get_values(self):


### PR DESCRIPTION
### Motivation
- Align the module version with Odoo 19 convention by using `19.0.1.0.0` in the manifest.
- Notify users that `stock_sms` is no longer listed in the manifest dependencies so they know to install it if they rely on SMS notifications.
- Persist configuration values via `ir.config_parameter` by binding settings fields, simplifying configuration storage and retrieval.

### Description
- Updated `voodoo_devices/__manifest__.py` to set `'version': '19.0.1.0.0'`.
- Added a note to `voodoo_devices/README.md` indicating that `stock_sms` must be present in the Odoo environment if SMS features are needed.
- Modified `voodoo_devices/models/res_config_settings.py` to add `config_parameter` attributes to `endpoint_url`, `username`, and `password` fields and reformatted the field definitions to multi-line for clarity.
- Kept existing `get_values` and `set_values` logic to read from and write to `ir.config_parameter`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a760e39c832bb2ba6b2b4e275a83)