### PR TITLE
Document `stock_sms` requirement in README

### DIFF
--- a/voodoo_devices/README.md
+++ b/voodoo_devices/README.md
@@ -7,6 +7,8 @@ Please note that if you're using BATCH or WAVE picking, there are three things y
 2) in the __manifest__.py file, you must uncomment any view_extension.xml line needed for your GUI.
 3) in the models/__init__.py file, you need to uncomment the lines to support your picking type.
 
+The `stock_sms` module is still required; be sure to install it alongside this addon since it is no longer listed in the default depends line.
+
 After activating this addon, you need to enter your Voodoo Devices credentials in the Settings panel and, if you're using feedback, you need to enter your Odoo credentials on you BigBlock server under the Setting tab.
 
 Since this addon depends on the queue_job addon, you may need to add the following to your odoo.conf file:


### PR DESCRIPTION
### Motivation
- Because `stock_sms` was removed from the `depends` line in `__manifest__.py`, the README should explicitly state that `stock_sms` is still required.

### Description
- Added a single-line note to `voodoo_devices/README.md` informing users that the `stock_sms` module must be installed alongside this addon.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a77b5314832baa9430dff928f728)